### PR TITLE
corrected invalid regex for determining image type

### DIFF
--- a/WPide.php
+++ b/WPide.php
@@ -1033,8 +1033,8 @@ class wpide
 					jQuery(".wpide_tab[sessionrel='"+ jQuery(".wpide_tab[rel='"+file+"']").attr("sessionrel") +"']").click();//focus the already open tab
 				    }else{ //open file
 					
-					var image_patern =new RegExp("(\.jpg|\.gif|\.png|\.bmp)");
-					if ( image_patern.test(file) ){
+					var image_pattern = new RegExp("(\\.jpg$|\\.gif$|\\.png$|\\.bmp$)");
+					if ( image_pattern.test(file) ){
 						//it's an image so open it for editing
 						
 						//using modal+iframe


### PR DESCRIPTION
Regex is invalid. Will detect filenames with GIF anywhere in the filename. Regex has been adjusted to only match filenames ending in GIF, JPG, etc.