### PR TITLE
Fix compatibility issues with WP All Import

### DIFF
--- a/WPide.php
+++ b/WPide.php
@@ -139,16 +139,17 @@ class wpide
 		//hide the update nag
 		add_action('admin_menu', array( &$this, 'hide_wp_update_nag' ));
 	}
+    
 
-	public function hide_wp_sidebar_nav($classes) {
-		global $hook_suffix;
-		
-		if ( apply_filters( 'wpide_sidebar_folded', $hook_suffix ===$this->menu_hook ) ) {
-			return str_replace("auto-fold", "", $classes) . ' folded';
-		}
-		return $classes;
-	}
+    public function hide_wp_sidebar_nav($classes) {
+        global $hook_suffix;
 
+        if ( apply_filters( 'wpide_sidebar_folded', $hook_suffix === $this->menu_hook ) ) {
+            return str_replace("auto-fold", "", $classes) . ' folded';
+        }
+        return $classes;
+    }
+    
     public function hide_wp_update_nag() {
         remove_action( 'admin_notices', 'update_nag', 3 );
     }

--- a/WPide.php
+++ b/WPide.php
@@ -139,16 +139,16 @@ class wpide
 		//hide the update nag
 		add_action('admin_menu', array( &$this, 'hide_wp_update_nag' ));
 	}
-    
 
-    public function hide_wp_sidebar_nav($classes) {
-        global $hook_suffix;
-
-		if ( apply_filters( 'wpide_sidebar_folded', $hook_suffix === $this->menu_hook ) ) {
-	    	return  str_replace("auto-fold", "", $classes) . ' folded';
+	public function hide_wp_sidebar_nav($classes) {
+		global $hook_suffix;
+		
+		if ( apply_filters( 'wpide_sidebar_folded', $hook_suffix ===$this->menu_hook ) ) {
+			return str_replace("auto-fold", "", $classes) . ' folded';
 		}
-    }
-    
+		return $classes;
+	}
+
     public function hide_wp_update_nag() {
         remove_action( 'admin_notices', 'update_nag', 3 );
     }


### PR DESCRIPTION
We ran in to an issue where styles from WPide were bleeding in to the admin pages for WP All Import. We've modified how WPide uses the admin_body_class filter and everything seems to be working ok.
